### PR TITLE
fix small dark mode issues

### DIFF
--- a/themes/clean-base/less/dark/clean-dark.less
+++ b/themes/clean-base/less/dark/clean-dark.less
@@ -14,10 +14,21 @@ a.list-group-item:hover, a.list-group-item.active, a.list-group-item.active:hove
   color: @text-color-highlight;
 }
 
+// Bottom Menu
+@media (max-width: 570px) {
+  #topbar > .container #top-menu-nav {
+    border-top-color: var(--background4);
+  }
+}
+
 // Notifications and Mail dropdown (unread messages)
 .messagePreviewEntry.unread,
 .media-list li.new {
   background-color: @background-color-highlight !important;
+}
+// Hide misplaced arrow
+#topbar > .container .notifications .arrow::after {
+  display: none;
 }
 
 // Profile Title and Subtitle


### PR DESCRIPTION
- hide misplaced arrow of notifications and mail dropdown (it is also not visible in the bright version of clean theme)
- darker border color for mobile bottom menu

Note: CSS still has to be recompiled.